### PR TITLE
Late editing pass - follow-up to #9

### DIFF
--- a/draft-irtf-cfrg-ristretto255-decaf448.md
+++ b/draft-irtf-cfrg-ristretto255-decaf448.md
@@ -91,8 +91,7 @@ compression</title>
 Edwards curves provide a number of implementation benefits for
 cryptography, such as complete addition formulas with no exceptional
 points and formulas among the fastest known for curve operations. However,
-every Edwards curve has a point of order 4. Thus, the group of
-points on the curve is not of prime order but has a small cofactor.
+the group of points on the curve is not of prime order and has a cofactor.
 This abstraction mismatch is usually handled by means of ad-hoc
 protocol tweaks (such as multiplying by the cofactor in an
 appropriate place), or not at all.
@@ -117,7 +116,8 @@ overhead, and only in the encoding and decoding phases.
 
 While Ristretto is a general method, and can be used in conjunction
 with any Edwards curve with cofactor 4 or 8, this document specifies
-the ristretto255 group, which MAY be implemented using Curve25519.
+the ristretto255 group, which MAY be implemented using Curve25519,
+and the decaf448 group, which MAY be implemented using edwards448.
 
 There are other elliptic curves that can be used internally to
 implement ristretto255 or decaf448, and those implementations would be

--- a/draft-irtf-cfrg-ristretto255-decaf448.md
+++ b/draft-irtf-cfrg-ristretto255-decaf448.md
@@ -91,7 +91,7 @@ compression</title>
 Edwards curves provide a number of implementation benefits for
 cryptography, such as complete addition formulas with no exceptional
 points and formulas among the fastest known for curve operations. However,
-the group of points on the curve is not of prime order and has a cofactor.
+the group of points on the curve is not of prime order, i.e., it has a cofactor larger than 1.
 This abstraction mismatch is usually handled by means of ad-hoc
 protocol tweaks (such as multiplying by the cofactor in an
 appropriate place), or not at all.
@@ -116,8 +116,8 @@ overhead, and only in the encoding and decoding phases.
 
 While Ristretto is a general method, and can be used in conjunction
 with any Edwards curve with cofactor 4 or 8, this document specifies
-the ristretto255 group, which MAY be implemented using Curve25519,
-and the decaf448 group, which MAY be implemented using edwards448.
+the ristretto255 group, which can be implemented using Curve25519,
+and the decaf448 group, which can be implemented using edwards448.
 
 There are other elliptic curves that can be used internally to
 implement ristretto255 or decaf448, and those implementations would be
@@ -251,9 +251,8 @@ element are equivalent.
 The one-way map is a function from uniformly distributed byte strings
 of a fixed length to uniformly distributed abstract elements. This map
 is suitable for hash-to-group operations and to select random elements.
-The map is not intended to be invertible, but its one-way nature alone
-should not be relied on for security, as it's possible to find valid
-inputs for a given output.
+The map is not invertible, but also not pre-image resistant,
+meaning an attacker can find a valid input for a given output.
 
 Addition is the group operation. The group has an identity element and
 prime order. Adding an element to itself as many times as the order of

--- a/draft-irtf-cfrg-ristretto255-decaf448.md
+++ b/draft-irtf-cfrg-ristretto255-decaf448.md
@@ -90,7 +90,7 @@ compression</title>
 
 Edwards curves provide a number of implementation benefits for
 cryptography, such as complete addition formulas with no exceptional
-points and formulae among the fastest known for curve operations. However,
+points and formulas among the fastest known for curve operations. However,
 every Edwards curve has a point of order 4. Thus, the group of
 points on the curve is not of prime order but has a small cofactor.
 This abstraction mismatch is usually handled by means of ad-hoc
@@ -308,8 +308,8 @@ Implementations **MUST NOT** expose them to their API consumers.
 * `D` = 37095705934669439343138083508754565189542113879843219016388785533085940283555
   * This is the Edwards d parameter for Curve25519, as specified in Section 4.1 of [@RFC7748].
 * `SQRT_M1` = 19681161376707505956807079304988542015446066515923890162744021073123829784752
-* `INVSQRT_A_MINUS_D` = 54469307008909316920995813868745141605393597292927456921205312896311721017578
 * `SQRT_AD_MINUS_ONE` = 25063068953384623474111414158702152701244531502492656460079210482610430750235
+* `INVSQRT_A_MINUS_D` = 54469307008909316920995813868745141605393597292927456921205312896311721017578
 * `ONE_MINUS_D_SQ` = 1159843021668779879193775521855586647937357759715417654439879720876111806838
 * `D_MINUS_ONE_SQ` = 40440834346308536858101042469323190826248399146238708352240133220865137265952
 
@@ -362,7 +362,7 @@ return (was_square, r)
 
 ### Decode {#decoding255}
 
-All elements are encoded as as a 32-byte strings. Decoding proceeds as follows:
+All elements are encoded as a 32-byte string. Decoding proceeds as follows:
 
 1. First, interpret the string as an integer s in little-endian
    representation. If the length of the string is not 32 bytes, or if
@@ -506,7 +506,7 @@ The scalars for the ristretto255 group are integers modulo the order l
 of the ristretto255 group. Note that this is the same scalar field as
 Curve25519, allowing existing implementations to be reused.
 
-Scalars are encoded as 56-byte strings in little-endian order.
+Scalars are encoded as 32-byte strings in little-endian order.
 Implementations **SHOULD** check that any scalar s falls in the range
 0 <= s < l when parsing them and reject non-canonical scalar
 encodings. Implementations **SHOULD** reduce scalars modulo l when
@@ -567,7 +567,8 @@ This document references the following constant field element values.
 Implementations **MUST NOT** expose them to their API consumers.
 
 * `D` = 726838724295606890549323807888004534353641360687318060281490199180612328166730772686396383698676545930088884461843637361053498018326358
-  * This is the Edwards d parameter for edwards448, as specified in Section 4.2 of [@RFC7748], and is equal to -39081 in the field.
+  * This is the Edwards d parameter for edwards448, as specified in
+    Section 4.2 of [@RFC7748], and is equal to -39081 in the field.
 * `ONE_MINUS_D` = 39082
 * `ONE_MINUS_TWO_D` = 78163
 * `SQRT_MINUS_D` = 98944233647732219769177004876929019128417576295529901074099889598043702116001257856802131563896515373927712232092845883226922417596214


### PR DESCRIPTION
Thanks @isislovecruft for the changes in #9, and sorry for not getting around to reviewing them. I finally did an editing pass as I saw we are heading into WGLC.

* The use of "byte string" or "bytestring" was inconsistent across the document. I feel like "32-byte string" reads much better than "bytestring of 32 bytes in length" (no repetition, shorter, doesn't add a component to the sentence) while still being unambiguous, so I added a definition of "N-byte string" to Section 2 and switched everything to it.

* Trimmed the naming historical context which is interesting but IMHO out of scope for a document aimed at implementers (while pointing out what the thing is called in other documents definitely helps).

* Removed the "Internal point representations" section. Section 2 already mentioned that all coordinates are in extended coordinates, and I moved the reference to RFC 8032 there. The fact that internal representations are points on Curve25519/edwards448 is already mentioned at the beginning of the #ristretto255 and #decaf448 sections.

  > This document describes how to implement the ristretto255 prime-order group using Curve25519 points as internal representations.

* Mentioned the hex encoding with whitespace of elements in Section 2 rather than having to mention it every time we encode an element.

* Addressed Pornin's note about not making the one-way map sound like a secure one-way function (although in #interface rather than where it was suggested).

* Removed the `A` constant and the note about the sign of the square roots. I think that was a useful conversation to have to make sure we were standardizing what we intended to, but I think they are out of scope for a document aimed at an implementer. An unused constant could lead to confusion, and the explanation of why SQRT_AD_MINUS_ONE is the negative square root is partial and sounds like it was intentional: the full explanation would mention that it's because it was generated with Sage and Sage has a different opinion of what is non-negative. That's wholly uninteresting to the implementer, and anyway we don't justify any of the formulae or constants: anyone who wants to know about them can follow the reference to the papers.

* Trimmed the final step of encoding. I agree that "reduced modulo p" is meaningless to say about a field element which is defined as "values modulo p", but I think that makes "the N-byte little-endian encoding of s" sufficient rather than requiring "the N-byte little-endian encoding of the unique integer representation of s as an integer in the 0 to p-1 range".

* Trimmed the first step of the MAP function. Again, I agree that "the least significant 255 bits of the string" is under-specified, but I think "interpret as little-endian, reduce modulo 2^255, then further reduce modulo p" is sufficient and more concise.

* Reflowed the last paragraph of the scalar field sections into the first two to avoid repetitions.

* Mentioned that reducing a N-byte uniformly distributed value modulo l is a way to get a _uniformly distributed_ scalar, not just any scalar, per Pornin's suggestion. I tried to work in a rationale about bias margins and consistency, but eventually decided the reason it was hard to do concisely was that it's out of scope for the document.

* Addressed Pornin's comment in API Considerations about being allowed to construct group elements through group operations.

* Finally, mirrored some changes between the r255 and the d448 sections, and some very minor formatting and copy edits.