### PR TITLE
"Bump" version to -07 and regenerate

### DIFF
--- a/draft-irtf-cfrg-ristretto255-decaf448.html
+++ b/draft-irtf-cfrg-ristretto255-decaf448.html
@@ -21,7 +21,7 @@ decaf448 group can be implemented using edwards448.
        This document is a product of the Crypto Forum Research Group (CFRG) in the IRTF. 
     " name="description">
 <meta content="xml2rfc 3.17.0" name="generator">
-<meta content="draft-irtf-cfrg-ristretto255-decaf448-08" name="ietf.draft">
+<meta content="draft-irtf-cfrg-ristretto255-decaf448-07" name="ietf.draft">
 <!-- Generator version information:
   xml2rfc 3.17.0
     Python 3.9.16
@@ -1229,7 +1229,7 @@ li > p:last-of-type:only-child {
 <dt class="label-workgroup">Workgroup:</dt>
 <dd class="workgroup">Crypto Forum Research Group</dd>
 <dt class="label-internet-draft">Internet-Draft:</dt>
-<dd class="internet-draft">draft-irtf-cfrg-ristretto255-decaf448-08</dd>
+<dd class="internet-draft">draft-irtf-cfrg-ristretto255-decaf448-07</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
 <time datetime="2023-04-04" class="published">4 April 2023</time>

--- a/draft-irtf-cfrg-ristretto255-decaf448.md
+++ b/draft-irtf-cfrg-ristretto255-decaf448.md
@@ -10,7 +10,7 @@
     [seriesInfo]
     status = "informational"
     name = "Internet-Draft"
-    value = "draft-irtf-cfrg-ristretto255-decaf448-08"
+    value = "draft-irtf-cfrg-ristretto255-decaf448-07"
     stream = "IETF"
 
     [[author]]

--- a/draft-irtf-cfrg-ristretto255-decaf448.txt
+++ b/draft-irtf-cfrg-ristretto255-decaf448.txt
@@ -17,7 +17,7 @@ Expires: 6 October 2023
 
 
                   The ristretto255 and decaf448 Groups
-                draft-irtf-cfrg-ristretto255-decaf448-08
+                draft-irtf-cfrg-ristretto255-decaf448-07
 
 Abstract
 

--- a/draft-irtf-cfrg-ristretto255-decaf448.xml
+++ b/draft-irtf-cfrg-ristretto255-decaf448.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- name="GENERATOR" content="github.com/mmarkdown/mmark Mmark Markdown Processor - mmark.miek.nl" -->
-<rfc version="3" ipr="trust200902" docName="draft-irtf-cfrg-ristretto255-decaf448-08" submissionType="IETF" category="info" xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude" indexInclude="true" consensus="true">
+<rfc version="3" ipr="trust200902" docName="draft-irtf-cfrg-ristretto255-decaf448-07" submissionType="IETF" category="info" xml:lang="en" xmlns:xi="http://www.w3.org/2001/XInclude" indexInclude="true" consensus="true">
 
 <front>
-<title abbrev="ristretto255-decaf448">The ristretto255 and decaf448 Groups</title><seriesInfo value="draft-irtf-cfrg-ristretto255-decaf448-08" stream="IETF" status="informational" name="Internet-Draft"></seriesInfo>
+<title abbrev="ristretto255-decaf448">The ristretto255 and decaf448 Groups</title><seriesInfo value="draft-irtf-cfrg-ristretto255-decaf448-07" stream="IETF" status="informational" name="Internet-Draft"></seriesInfo>
 <author initials="H." surname="de Valence" fullname="Henry de Valence"><organization></organization><address><postal><street></street>
 </postal><email>ietf@hdevalence.ca</email>
 </address></author><author initials="J." surname="Grigg" fullname="Jack Grigg"><organization></organization><address><postal><street></street>


### PR DESCRIPTION
During some previous release, the version in Markdown was bumped too far, and was only fixed in the XML version.